### PR TITLE
Fix link for vSphere Docker Volume Service

### DIFF
--- a/main.bundle.js
+++ b/main.bundle.js
@@ -137,7 +137,7 @@ var AppComponent = (function () {
                 "name": "vSphere Docker Volume Service (vDVS)",
                 "image": "github_icon.svg",
                 "description": "Enterprise grade, Storage and Data services for Stateful Cloud Native Applications",
-                "url": "https://vmware.github.io/vsphere-storage-for-docker/"
+                "url": "https://vmware.github.io/docker-volume-vsphere/"
             },
             {
                 "name": "vSphere® Integrated Containers™",


### PR DESCRIPTION
Current link on page is broken. Restore original link until we figure out a way to redirect old links to new one.